### PR TITLE
Move back runtime import to visitor

### DIFF
--- a/packages/regenerator-transform/src/util.js
+++ b/packages/regenerator-transform/src/util.js
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { addDefault } from "@babel/helper-module-imports";
-
 let currentTypes = null;
 
 export function wrapWithTypes(types, fn) {
@@ -27,26 +25,8 @@ export function getTypes() {
 
 const runtimeNames = new WeakMap();
 
-export function runtimeProperty(name, scope, opts) {
+export function runtimeProperty(runtimeId, name) {
   const t = getTypes();
-
-  let runtimeId;
-  if (!opts.importRuntime) {
-    runtimeId = t.identifier("regeneratorRuntime");
-  } else {
-    const programPath = scope.getProgramParent().path;
-    if (runtimeNames.has(programPath.node)) {
-      runtimeId = t.identifier(runtimeNames.get(programPath.node));
-    } else {
-      runtimeId = addDefault(programPath, "regenerator-runtime", {
-        nameHint: "regeneratorRuntime",
-        importedInterop: "uncompiled",
-        blockHoist: 3
-      });
-      runtimeNames.set(programPath.node, runtimeId.name);
-    }
-  }
-
   return t.memberExpression(
     runtimeId,
     t.identifier(name),


### PR DESCRIPTION
I agree with @benjamn that we should move `scope` and `option` out of `util.js`
so I moved it to the `util.js`

and it make more senses to give `runtimeProperty` two arguments, `runtimeId` and `name` .